### PR TITLE
GH #10 - Forcing process to wait for process to complete

### DIFF
--- a/CsmakeModules/Signature.py
+++ b/CsmakeModules/Signature.py
@@ -111,6 +111,7 @@ class Signature(CsmakeModuleAllPhase):
             self.ready.set()
             self.finish.wait()
             self.input.close()
+            self.process.wait()
             buf = self.process.stdout.read()
             self.output = []
             while len(buf) > 0:
@@ -119,7 +120,6 @@ class Signature(CsmakeModuleAllPhase):
                     buf = self.process.stdout.read()
                 except:
                     break
-            self.process.wait()
             self.parent._unregisterOnExitCallback("_stopSigner")
             result = self.process.returncode
             self.failed = result != 0

--- a/csmakefile
+++ b/csmakefile
@@ -33,7 +33,7 @@ test=Run testing for csmake
 
 [metadata@csmake-swak]
 name=csmake-swak
-version=1.1.9
+version=1.1.10
 description=csmake swiss army knife library
 about=csmake library providing a useful suite of basic modules
  for testing modules, specialized shell outs, specialized versioning


### PR DESCRIPTION
The process.wait() was after the read, which if timing was incorrect,
could have caused a false empty read, occasionally causing failure.